### PR TITLE
Refactoring and optimization

### DIFF
--- a/src/core/MultiButton.h
+++ b/src/core/MultiButton.h
@@ -12,18 +12,10 @@ class MultiButton : public VirtButton {
         b0.tickRaw();
         b1.tickRaw();
 
-        if (bf.read(EB_BOTH)) {
-            if (!b0.pressing() && !b1.pressing()) bf.clear(EB_BOTH);
-            if (!b0.pressing()) b0.reset();
-            if (!b1.pressing()) b1.reset();
-            b0.clear();
-            b1.clear();
-            return VirtButton::tick(true);
-        } else {
-            if (b0.pressing() && b1.pressing()) bf.set(EB_BOTH);
+        if (!bf.read(EB_BOTH)) {
             b0.call();
             b1.call();
-            return VirtButton::tick(false);
         }
+        return VirtButton::tick(b0, b1);
     }
 };

--- a/src/core/VirtButton.h
+++ b/src/core/VirtButton.h
@@ -206,7 +206,7 @@ class VirtButton {
 
     // кнопка отпущена (в любом случае) [событие]
     bool release() {
-        return bf.eq(EB_REL_R | EB_REL, EB_REL_R | EB_REL);
+        return bf.all(EB_REL_R | EB_REL);
     }
 
     // кнопка отпущена (в любом случае) с предварительными кликами [событие]
@@ -246,7 +246,7 @@ class VirtButton {
 
     // кнопка удерживается (больше таймаута) [состояние]
     bool holding() {
-        return bf.eq(EB_PRS | EB_HLD, EB_PRS | EB_HLD);
+        return bf.all(EB_PRS | EB_HLD);
     }
 
     // кнопка удерживается (больше таймаута) с предварительными кликами [состояние]
@@ -304,7 +304,7 @@ class VirtButton {
 
     // кнопка отпущена после импульсного удержания с предварительными кликами [событие]
     bool releaseStep(const uint8_t num) {
-        return clicks == num && bf.eq(EB_CLKS_R | EB_STP, EB_CLKS_R | EB_STP);
+        return clicks == num && bf.all(EB_CLKS_R | EB_STP);
     }
 
     // кнопка отпущена после удержания или импульсного удержания [событие]

--- a/src/core/VirtButton.h
+++ b/src/core/VirtButton.h
@@ -165,12 +165,10 @@ class VirtButton {
 
     // принудительно сбросить флаги событий
     void clear(bool resetTout = false) {
-        if (resetTout && bf.read(EB_TOUT)) bf.clear(EB_TOUT);
+        if (resetTout) bf.clear(EB_TOUT);
         if (bf.read(EB_CLKS_R)) clicks = 0;
-        if (bf.read(EB_CLKS_R | EB_STP_R | EB_PRS_R | EB_HLD_R | EB_REL_R)) {
             bf.clear(EB_CLKS_R | EB_STP_R | EB_PRS_R | EB_HLD_R | EB_REL_R);
         }
-    }
 
     // игнорировать все события до отпускания кнопки
     void skipEvents() {
@@ -564,7 +562,7 @@ class VirtButton {
             } else if (clicks) {                                                                // есть клики, ждём EB_CLICK_TIME
                 if (bf.read(EB_HLD | EB_STP) || deb >= EB_GET_CLICK_TIME()) bf.set(EB_CLKS_R);  // флаг clicks
 #ifndef EB_NO_FOR
-                else if (ftmr) ftmr = 0;
+                else ftmr = 0;
 #endif
             } else if (bf.read(EB_BUSY)) {
                 bf.clear(EB_HLD | EB_STP | EB_BUSY);
@@ -574,7 +572,7 @@ class VirtButton {
 #endif
                 tmr = ms;  // test!!
             }
-            if (bf.read(EB_DEB)) bf.clear(EB_DEB);  // сброс ожидания нажатия (дебаунс)
+            bf.clear(EB_DEB);  // сброс ожидания нажатия (дебаунс)
         }
         return bf.read(EB_CLKS_R | EB_PRS_R | EB_HLD_R | EB_STP_R | EB_REL_R);
     }

--- a/src/core/VirtButton.h
+++ b/src/core/VirtButton.h
@@ -86,6 +86,7 @@ enum class EBAction {
 #define EB_HLD_R (1 << 2)
 #define EB_STP_R (1 << 3)
 #define EB_REL_R (1 << 4)
+#define EB_ALL_R (EB_CLKS_R | EB_PRS_R | EB_HLD_R | EB_STP_R | EB_REL_R)
 
 #define EB_PRS (1 << 5)
 #define EB_HLD (1 << 6)
@@ -167,8 +168,8 @@ class VirtButton {
     void clear(bool resetTout = false) {
         if (resetTout) bf.clear(EB_TOUT);
         if (bf.read(EB_CLKS_R)) clicks = 0;
-            bf.clear(EB_CLKS_R | EB_STP_R | EB_PRS_R | EB_HLD_R | EB_REL_R);
-        }
+        bf.clear(EB_ALL_R);
+    }
 
     // игнорировать все события до отпускания кнопки
     void skipEvents() {
@@ -327,7 +328,7 @@ class VirtButton {
 
     // было действие с кнопки, вернёт код события [событие]
     uint16_t action() {
-        switch (bf.mask(0b111111111)) {
+        switch (bf.mask(EB_ALL_R | EB_PRS | EB_HLD | EB_STP | EB_REL)) {
             case (EB_PRS | EB_PRS_R): return EB_PRESS;
             case (EB_PRS | EB_HLD | EB_HLD_R): return EB_HOLD;
             case (EB_PRS | EB_HLD | EB_STP | EB_STP_R): return EB_STEP;
@@ -574,6 +575,6 @@ class VirtButton {
             }
             bf.clear(EB_DEB);  // сброс ожидания нажатия (дебаунс)
         }
-        return bf.read(EB_CLKS_R | EB_PRS_R | EB_HLD_R | EB_STP_R | EB_REL_R);
+        return bf.read(EB_ALL_R);
     }
 };

--- a/src/core/VirtButton.h
+++ b/src/core/VirtButton.h
@@ -317,7 +317,7 @@ class VirtButton {
 
     // кнопка ожидает повторных кликов [состояние]
     bool waiting() {
-        return clicks && bf.eq(EB_PRS | EB_REL, 0);
+        return clicks && !bf.read(EB_PRS | EB_REL);
     }
 
     // идёт обработка [состояние]

--- a/src/core/VirtEncButton.h
+++ b/src/core/VirtEncButton.h
@@ -168,8 +168,8 @@ class VirtEncButton : public VirtButton, public VirtEncoder {
         if (encf) {
             if (bf.read(EB_PRS)) bf.set(EB_EHLD);  // зажать энкодер
             else clicks = 0;
-            if (!bf.read(EB_TOUT)) bf.set(EB_TOUT);  // таймаут
-            ef.set(EB_ETRN_R);                       // флаг поворота
+            bf.set(EB_TOUT);    // таймаут
+            ef.set(EB_ETRN_R);  // флаг поворота
         }
         return VirtButton::tickRaw(btn) | encf;
     }

--- a/src/core/VirtEncButton.h
+++ b/src/core/VirtEncButton.h
@@ -82,19 +82,19 @@ class VirtEncButton : public VirtButton, public VirtEncoder {
     // обработка в прерывании (только энкодер). Вернёт 0 в покое, 1 или -1 при повороте
     int8_t tickISR(const bool e0, const bool e1) {
         int8_t state = VirtEncoder::pollEnc(e0, e1);
-        if (state) {
+        if (!state) return state;
+
 #ifdef EB_NO_BUFFER
-            ef.set(EB_ISR_F);
-            ef.write(EB_DIR, state > 0);
-            ef.write(EB_FAST, _checkFast());
+        ef.set(EB_ISR_F);
+        ef.write(EB_DIR, state > 0);
+        ef.write(EB_FAST, _checkFast());
 #else
-            for (uint8_t i = 0; i < 15; i += EB_BUF_LEN) {
-                if (ebuffer & (EB_BUF_TURN << i)) continue;
-                ebuffer |= (EB_BUF_TURN | ((state > 0) * EB_BUF_DIR) | (_checkFast() * EB_BUF_FAST)) << i;
-                break;
-            }
-#endif
+        for (uint8_t i = 0; i < 15; i += EB_BUF_LEN) {
+            if (ebuffer & (EB_BUF_TURN << i)) continue;
+            ebuffer |= (EB_BUF_TURN | ((state > 0) * EB_BUF_DIR) | (_checkFast() * EB_BUF_FAST)) << i;
+            break;
         }
+#endif
         return state;
     }
 

--- a/src/core/VirtEncoder.h
+++ b/src/core/VirtEncoder.h
@@ -11,7 +11,7 @@
 #define EB_STEP1 3
 
 // ===================== FLAGS ======================
-#define EB_TYPE (1 << 0)
+#define EB_TYPE ((1 << 0) | (1 << 1))
 #define EB_REV (1 << 2)
 #define EB_FAST (1 << 3)
 #define EB_DIR (1 << 4)
@@ -34,7 +34,7 @@ class VirtEncoder {
 
     // установить тип энкодера (EB_STEP4_LOW, EB_STEP4_HIGH, EB_STEP2, EB_STEP1)
     void setEncType(const uint8_t type) {
-        ef.clear(0b11111100);
+        ef.clear(~EB_TYPE);
         ef.set(type);
     }
 

--- a/src/core/VirtEncoder.h
+++ b/src/core/VirtEncoder.h
@@ -29,12 +29,13 @@ class VirtEncoder {
     // ====================== SET ======================
     // инвертировать направление энкодера
     void setEncReverse(const bool rev) {
-        rev ? ef.set(EB_REV) : ef.clear(EB_REV);
+        ef.write(EB_REV, rev);
     }
 
     // установить тип энкодера (EB_STEP4_LOW, EB_STEP4_HIGH, EB_STEP2, EB_STEP1)
     void setEncType(const uint8_t type) {
-        ef.flags = (ef.flags & 0b11111100) | type;
+        ef.clear(0b11111100);
+        ef.set(type);
     }
 
     // использовать обработку энкодера в прерывании

--- a/src/core/VirtEncoder.h
+++ b/src/core/VirtEncoder.h
@@ -97,12 +97,7 @@ class VirtEncoder {
         int8_t state = tickRaw();
         if (state) return state;
 
-        state = pollEnc(e0, e1);
-        if (state) {
-            ef.write(EB_DIR, state > 0);
-            ef.set(EB_ETRN_R);
-        }
-        return state;
+        return tickISR(e0, e1);
     }
 
     // опросить энкодер без сброса события поворота (сам опрос в прерывании)

--- a/src/core/VirtEncoder.h
+++ b/src/core/VirtEncoder.h
@@ -50,7 +50,7 @@ class VirtEncoder {
 
     // сбросить флаги событий
     void clear() {
-        if (ef.read(EB_ETRN_R)) ef.clear(EB_ETRN_R);
+        ef.clear(EB_ETRN_R);
     }
 
     // ====================== ОПРОС ======================

--- a/src/core/flags.h
+++ b/src/core/flags.h
@@ -25,6 +25,9 @@ struct Flags {
     inline bool eq(const T x, const T y) __attribute__((always_inline)) {
         return (flags & x) == y;
     }
+    inline bool all(const T x) __attribute__((always_inline)) {
+        return eq(x, x);
+    }
 };
 
 }  // namespace encb


### PR DESCRIPTION
Насколько удалось протестировать, изменения не меняют поведения программы - это, по большей части, только рефакторинг и оптимизации

Пару комментариев:

[059b061 - Remove redundant conditions](dakalamin/EncButton/059b0612349d8edc015eb26ed3d485cbf088bee6)
Во всех этих ситуациях значения можно сбрасывать без их предварительной проверки - результат будет один и тот же

[13c4bf7 - Optimize and simplify](dakalamin/EncButton/13c4bf7d5d316de50cd5a530a5ef35e784d5cc0e)
_MultiButton.h_ - `bool tick(T0& b0, T1& b1)` дублирует код из `bool VirtButton::tick(VirtButton& b0, VirtButton& b1)`, не хватает только `b0.call()` и `b1.call()`
_VirtEncoder.h_ - Аналогично с `int8_t tickRaw(const bool e0, const bool e1)` и `int8_t tickISR(const bool e0, const bool e1)`
_VirtEncButton.h_ - В `bool _tickRaw(bool btn, int8_t estate)` можно обойтись без флага `encf`

Остальное:
- В _MultiButton.h_ шаблонные `T0` и `T1` никак не подсказывают, объектами каких классов они могут быть. Тут же проблемы отсутстувия подсветки синтаксиса, эльфийские сообщения комплиятора, если есть ошибки с этим классом, и запутанная ситуация с практической разницей между `MultiButton::tick(T0& b0, T1& b1)` и `VirtButton::tick(VirtButton& b0, VirtButton& b1)`. Как пример того, что проблема существенная, это ошибка в _README_: https://github.com/GyverLibs/EncButton/blob/489c34a2e38ecc3dc128b48c998a8cdb92084e74/README.md?plain=1#L1120
Попытка передать `VirtButton` в `MultiButton` приводит к ошибке, т.к. у `VirtButton` нет метода `tickRaw()`, только `tickRaw(const bool s)`:
  ```c++
  #include <EncButton.h>
  
  VirtButton a, b;
  MultiButton c;
  
  void setup() { }
  void loop() {
    c.tick(a, b);
  }
  ```
  Из потенциальных решений - завести интерфейс для кнопки по типу:
  ```c++
  class IButton {
  public:
    virtual bool read() = 0;
    virtual bool tick() = 0;
    virtual bool tickRaw() = 0;
  };
  ```
  и наследовать его в классах `Button/ButtonT` и `EncButton/EncButtonT` (в таком случае, возможно, стоило бы сделать то же самое и с классом энкодера)
- В _README_ несколько раз упомянается метод `readEnc` для `EncButton/EncButtonT`, которого не существует: https://github.com/GyverLibs/EncButton/blob/489c34a2e38ecc3dc128b48c998a8cdb92084e74/README.md?plain=1#L228-L230 https://github.com/GyverLibs/EncButton/blob/489c34a2e38ecc3dc128b48c998a8cdb92084e74/README.md?plain=1#L615-L616
  Cоответственно, следует либо добавить его в код, либо убрать его из _README_
- Английская версия _README_ - это полная катастрофа, где все от бессмысленного текста до сломанного форматирования. Тут либо выбрать другой сервис для автоматического перевода и после вручную проверять Markdown форматирование, периодически синхронизируя с обновлениями в основном файле, либо совсем отказаться от переведенной версии, оставляя это на потенциального пользователя